### PR TITLE
Modify azureToken service so we persist it on database

### DIFF
--- a/src/main/java/br/com/klimber/inova/config/SecurityConfig.java
+++ b/src/main/java/br/com/klimber/inova/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -32,6 +33,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	private String adminFirstName;
 	@Value("${customer.admin.lastname}")
 	private String adminLastName;
+	@Value("${spring.profiles.active}")
+	private String profile;
 
 	@Autowired
 	private CustomerRepository customerRepository;
@@ -58,6 +61,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	@Bean
 	protected PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	@Override
+	public void configure(WebSecurity web) throws Exception {
+//		Ignore h2-console security on development so we can access it
+		if (profile.equals("dev")) {
+			web.ignoring().antMatchers("/h2-console/**");
+		}
 	}
 
 }

--- a/src/main/java/br/com/klimber/inova/model/AzureToken.java
+++ b/src/main/java/br/com/klimber/inova/model/AzureToken.java
@@ -3,13 +3,20 @@ package br.com.klimber.inova.model;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
 import com.fasterxml.jackson.annotation.JsonAlias;
 
 import lombok.Data;
 
 @Data
+@Entity
 public class AzureToken {
 
+	@Id
+	private final Long id = 1L;
 	@JsonAlias("token_type")
 	private String tokenType;
 	@JsonAlias("expires_in")
@@ -18,6 +25,7 @@ public class AzureToken {
 	private Long extExpiresIn; // seconds
 	private Instant expiresOn;
 	@JsonAlias("access_token")
+	@Column(length = 4000)
 	private String accessToken;
 
 	public void setExpires_in(Long expires_in) {

--- a/src/main/java/br/com/klimber/inova/repository/AzureTokenRepository.java
+++ b/src/main/java/br/com/klimber/inova/repository/AzureTokenRepository.java
@@ -1,0 +1,11 @@
+package br.com.klimber.inova.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.klimber.inova.model.AzureToken;
+
+@Repository
+public interface AzureTokenRepository extends JpaRepository<AzureToken, Long> {
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,13 @@ customer:
     firstname: Sysadmin
     lastname: Sysadmin
 
+spring:
+  jpa:
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+
 azure:
   app:
     client-id: <azure-client-id>


### PR DESCRIPTION
In order to do less calls to get AzureToken, store it in the database as a single line table, this way we can restart the app without calling azure again.
#15 