### PR TITLE
Alterado tamanho da coluna embedUrl da tabela reports

### DIFF
--- a/src/main/java/br/com/klimber/inova/model/Report.java
+++ b/src/main/java/br/com/klimber/inova/model/Report.java
@@ -1,5 +1,6 @@
 package br.com.klimber.inova.model;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -18,6 +19,7 @@ public class Report {
 	private String reportType;
 	private String name;
 	private String webUrl;
+	@Column(length = 1024)
 	private String embedUrl;
 	private boolean isFromPbix;
 	private boolean isOwnedByMe;


### PR DESCRIPTION
O tamanho dos dados enviados pela API do PowerBI ultrapassou 255 caracteres. Com isso o job de update parou de funcionar. Estou aumentado o tamanho da coluna.