### PR TITLE
Patch Customer can now define admins

### DIFF
--- a/src/main/java/br/com/klimber/inova/dto/PatchCustomerDTOAdmin.java
+++ b/src/main/java/br/com/klimber/inova/dto/PatchCustomerDTOAdmin.java
@@ -17,4 +17,6 @@ public class PatchCustomerDTOAdmin {
 
 	private String password;
 
+	private Boolean isAdmin;
+
 }

--- a/src/main/java/br/com/klimber/inova/endpoint/CustomerEndpoint.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/CustomerEndpoint.java
@@ -126,6 +126,13 @@ public class CustomerEndpoint {
 		if (!StringUtils.isEmpty(customerPatch.getPassword())) {
 			customer.setPassword(passwordEncoder.encode(customerPatch.getPassword()));
 		}
+		if (customerPatch.getIsAdmin()) {
+			customer.addAuthority("ROLE_ADMIN");
+			customer.removeAuthority("ROLE_USER");
+		} else {
+			customer.addAuthority("ROLE_USER");
+			customer.removeAuthority("ROLE_ADMIN");
+		}
 		return customerMapper.toDTO(customerService.save(customer));
 	}
 


### PR DESCRIPTION
The CustomerEndpoint Patch method can now define or un-define other users as admins.