### PR TITLE
Switch to profile access control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
 	id 'org.springframework.boot' version '2.2.0.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
 	id 'java'
-	id "net.ltgt.apt" version "0.21"
 	id 'eclipse'
 	id 'idea'
 }

--- a/src/main/java/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/java/META-INF/additional-spring-configuration-metadata.json
@@ -30,16 +30,6 @@
     "description": "URL for frontend, will be used for cors"
   },
   {
-    "name": "app.client-id",
-    "type": "java.lang.String",
-    "description": "Client id for frontend app"
-  },
-  {
-    "name": "app.client-secret",
-    "type": "java.lang.String",
-    "description": "Client id for frontend app"
-  },
-  {
     "name": "app.azure.client-id",
     "type": "java.lang.String",
     "description": "Client id for azure app"

--- a/src/main/java/br/com/klimber/inova/dto/CreateCustomerDTO.java
+++ b/src/main/java/br/com/klimber/inova/dto/CreateCustomerDTO.java
@@ -1,0 +1,24 @@
+package br.com.klimber.inova.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class CreateCustomerDTO {
+
+	private String username;
+	@NotBlank
+	private String fullName;
+	@NotBlank
+	private String extraInfo;
+	@Email
+	@NotBlank
+	private String email;
+	@NotBlank
+	private String password;
+	@NotBlank
+	private Long profileId;
+
+}

--- a/src/main/java/br/com/klimber/inova/dto/CustomerDTO.java
+++ b/src/main/java/br/com/klimber/inova/dto/CustomerDTO.java
@@ -1,5 +1,7 @@
 package br.com.klimber.inova.dto;
 
+import java.util.Set;
+
 import br.com.klimber.inova.model.Customer;
 import lombok.Data;
 
@@ -18,6 +20,8 @@ public class CustomerDTO {
 
 	private Long profileId;
 
+	private Set<String> extraAuthorities;
+
 	public CustomerDTO(Customer customer) {
 		this.id = customer.getId();
 		this.username = customer.getUsername();
@@ -25,6 +29,7 @@ public class CustomerDTO {
 		this.fullName = customer.getFullName();
 		this.extraInfo = customer.getExtraInfo();
 		this.profileId = customer.getProfile().getId();
+		this.extraAuthorities = customer.getExtraAuthorities();
 	}
 
 }

--- a/src/main/java/br/com/klimber/inova/dto/PatchCustomerDTOAdmin.java
+++ b/src/main/java/br/com/klimber/inova/dto/PatchCustomerDTOAdmin.java
@@ -15,8 +15,8 @@ public class PatchCustomerDTOAdmin {
 
 	private String extraInfo;
 
-	private String password;
+	private Long profileId;
 
-	private Boolean isAdmin;
+	private String password;
 
 }

--- a/src/main/java/br/com/klimber/inova/dto/ProfileDTO.java
+++ b/src/main/java/br/com/klimber/inova/dto/ProfileDTO.java
@@ -1,0 +1,23 @@
+package br.com.klimber.inova.dto;
+
+import javax.validation.constraints.NotBlank;
+
+import br.com.klimber.inova.model.CustomerProfile;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ProfileDTO {
+
+	private Long id;
+
+	@NotBlank
+	private String name;
+
+	public ProfileDTO(CustomerProfile profile) {
+		this.id = profile.getId();
+		this.name = profile.getName();
+	}
+
+}

--- a/src/main/java/br/com/klimber/inova/dto/WhoAmIDTO.java
+++ b/src/main/java/br/com/klimber/inova/dto/WhoAmIDTO.java
@@ -1,10 +1,15 @@
 package br.com.klimber.inova.dto;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+
 import br.com.klimber.inova.model.Customer;
 import lombok.Data;
 
 @Data
-public class CustomerDTO {
+public class WhoAmIDTO {
 
 	private Long id;
 
@@ -18,13 +23,16 @@ public class CustomerDTO {
 
 	private Long profileId;
 
-	public CustomerDTO(Customer customer) {
+	private Set<String> authorities;
+
+	public WhoAmIDTO(Customer customer) {
 		this.id = customer.getId();
 		this.username = customer.getUsername();
 		this.email = customer.getEmail();
 		this.fullName = customer.getFullName();
 		this.extraInfo = customer.getExtraInfo();
 		this.profileId = customer.getProfile().getId();
+		this.authorities = customer.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+				.collect(Collectors.toSet());
 	}
-
 }

--- a/src/main/java/br/com/klimber/inova/endpoint/CustomerEndpoint.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/CustomerEndpoint.java
@@ -1,22 +1,19 @@
 package br.com.klimber.inova.endpoint;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Example;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
-import br.com.klimber.inova.dto.ChangePasswordDTO;
-import br.com.klimber.inova.dto.CustomerDTO;
-import br.com.klimber.inova.dto.PatchCustomerDTOAdmin;
+import br.com.klimber.inova.dto.*;
 import br.com.klimber.inova.model.Customer;
+import br.com.klimber.inova.model.CustomerProfile;
+import br.com.klimber.inova.service.CustomerProfileService;
 import br.com.klimber.inova.service.CustomerService;
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class CustomerEndpoint {
 
 	private final CustomerService customerService;
+	private final CustomerProfileService profileService;
 	private final PasswordEncoder passwordEncoder;
 
 	/**
@@ -50,10 +48,17 @@ public class CustomerEndpoint {
 
 	@Secured("ROLE_ADMIN")
 	@PostMapping("/customers")
-	public CustomerDTO addCustomer(@RequestBody Customer customer) {
-		customer.setId(null);
-		customer.setAuthorities(Set.of("ROLE_USER"));
-		customer.setPassword(passwordEncoder.encode(customer.getPassword()));
+	public CustomerDTO addCustomer(@RequestBody CreateCustomerDTO customerDTO) {
+		CustomerProfile profile = profileService.findById(customerDTO.getProfileId());
+		Customer customer = Customer.builder()
+				.id(null)
+				.username(customerDTO.getUsername())
+				.fullName(customerDTO.getFullName())
+				.extraInfo(customerDTO.getExtraInfo())
+				.email(customerDTO.getEmail())
+				.password(passwordEncoder.encode(customerDTO.getPassword()))
+				.profile(profile)
+				.build();
 		return new CustomerDTO(customerService.save(customer));
 	}
 
@@ -69,32 +74,9 @@ public class CustomerEndpoint {
 		return new CustomerDTO(customerService.findById(id));
 	}
 
-	@RequestMapping(method = RequestMethod.OPTIONS, path = "/customers")
-	public ResponseEntity<Object> options() {
-		return new ResponseEntity<>(HttpStatus.OK);
-	}
-
 	@GetMapping("/customers/whoAmI")
-	public CustomerDTO whoAmI() {
-		return new CustomerDTO((Customer) SecurityContextHolder.getContext().getAuthentication().getPrincipal());
-	}
-
-	@Secured("ROLE_ADMIN")
-	@PostMapping("/customers/{userId}/authority/{authority}")
-	public boolean addAuthority(@PathVariable Long userId, @PathVariable String authority) {
-		Customer customer = customerService.findById(userId);
-		customer.addAuthority(authority);
-		customerService.save(customer);
-		return true;
-	}
-
-	@Secured("ROLE_ADMIN")
-	@DeleteMapping("/customers/{userId}/authority/{authority}")
-	public boolean removeAuthority(@PathVariable Long userId, @PathVariable String authority) {
-		Customer customer = customerService.findById(userId);
-		customer.removeAuthority(authority);
-		customerService.save(customer);
-		return true;
+	public WhoAmIDTO whoAmI() {
+		return new WhoAmIDTO((Customer) SecurityContextHolder.getContext().getAuthentication().getPrincipal());
 	}
 
 	@PatchMapping("/changePassword")
@@ -111,20 +93,15 @@ public class CustomerEndpoint {
 	@Secured("ROLE_ADMIN")
 	@PatchMapping("/customer/{id}")
 	public CustomerDTO patchUserAdmin(@RequestBody PatchCustomerDTOAdmin customerPatch, @PathVariable("id") Long id) {
+		CustomerProfile profile = profileService.findById(customerPatch.getProfileId());
 		Customer customer = customerService.findById(id);
 		customer.setUsername(customerPatch.getUsername());
 		customer.setEmail(customerPatch.getEmail());
 		customer.setExtraInfo(customerPatch.getExtraInfo());
 		customer.setFullName(customerPatch.getFullName());
+		customer.setProfile(profile);
 		if (!StringUtils.isEmpty(customerPatch.getPassword())) {
 			customer.setPassword(passwordEncoder.encode(customerPatch.getPassword()));
-		}
-		if (customerPatch.getIsAdmin()) {
-			customer.addAuthority("ROLE_ADMIN");
-			customer.removeAuthority("ROLE_USER");
-		} else {
-			customer.addAuthority("ROLE_USER");
-			customer.removeAuthority("ROLE_ADMIN");
 		}
 		return new CustomerDTO(customerService.save(customer));
 	}

--- a/src/main/java/br/com/klimber/inova/endpoint/CustomerEndpoint.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/CustomerEndpoint.java
@@ -106,4 +106,16 @@ public class CustomerEndpoint {
 		return new CustomerDTO(customerService.save(customer));
 	}
 
+	@Secured("ROLE_ADMIN")
+	@PostMapping("/customer/{customerId}/authority/{authority}")
+	public void addExtraAuthority(@PathVariable Long customerId, @PathVariable String authority) {
+		customerService.addExtraAuthority(customerId, authority);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@DeleteMapping("/customer/{customerId}/authority/{authority}")
+	public void removeExtraAuthority(@PathVariable Long customerId, @PathVariable String authority) {
+		customerService.removeExtraAuthority(customerId, authority);
+	}
+
 }

--- a/src/main/java/br/com/klimber/inova/endpoint/CustomerProfileEndpoint.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/CustomerProfileEndpoint.java
@@ -1,0 +1,72 @@
+package br.com.klimber.inova.endpoint;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.*;
+
+import br.com.klimber.inova.dto.ProfileDTO;
+import br.com.klimber.inova.model.CustomerProfile;
+import br.com.klimber.inova.service.CustomerProfileService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CustomerProfileEndpoint {
+
+	private final CustomerProfileService profileService;
+
+	@Secured("ROLE_ADMIN")
+	@PostMapping("/profiles")
+	@ResponseStatus(code = HttpStatus.CREATED)
+	public CustomerProfile addProfile(@RequestBody @Valid ProfileDTO profileDTO) {
+		CustomerProfile profile = new CustomerProfile(profileDTO.getName(), Set.of("ROLE_USER"));
+		return profileService.save(profile);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@DeleteMapping("/profiles/{id}")
+	public void delProfile(@PathVariable Long id) {
+		profileService.deleteById(id);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@GetMapping("/profiles/{id}")
+	public CustomerProfile getProfile(@PathVariable Long id) {
+		return profileService.findByIdWithAuthorities(id);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@GetMapping("/profiles")
+	public List<ProfileDTO> getProfiles() {
+		return profileService.findAll().stream().map(ProfileDTO::new)
+				.collect(Collectors.toList());
+	}
+
+	@Secured("ROLE_ADMIN")
+	@PostMapping("/profiles/{profileId}/authority/{authority}")
+	public void addAuthority(@PathVariable Long profileId, @PathVariable String authority) {
+		profileService.addAuthority(profileId, authority);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@DeleteMapping("/profiles/{profileId}/authority/{authority}")
+	public void removeAuthority(@PathVariable Long profileId, @PathVariable String authority) {
+		profileService.removeAuthority(profileId, authority);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@PutMapping("/profiles/{profileId}")
+	public CustomerProfile putProfile(@PathVariable Long profileId, @RequestBody @Valid CustomerProfile profile) {
+		// ensure exists
+		profileService.findById(profileId);
+		profile.setId(profileId);
+		return profileService.save(profile);
+	}
+
+}

--- a/src/main/java/br/com/klimber/inova/endpoint/CustomerProfileEndpoint.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/CustomerProfileEndpoint.java
@@ -36,6 +36,14 @@ public class CustomerProfileEndpoint {
 	}
 
 	@Secured("ROLE_ADMIN")
+	@PatchMapping("/profiles/{id}")
+	public ProfileDTO patchProfile(@PathVariable Long id, @RequestBody @Valid ProfileDTO profileDTO) {
+		CustomerProfile profile = profileService.findById(id);
+		profile.setName(profileDTO.getName());
+		return new ProfileDTO(profileService.save(profile));
+	}
+
+	@Secured("ROLE_ADMIN")
 	@GetMapping("/profiles/{id}")
 	public CustomerProfile getProfile(@PathVariable Long id) {
 		return profileService.findByIdWithAuthorities(id);

--- a/src/main/java/br/com/klimber/inova/endpoint/PbiController.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/PbiController.java
@@ -1,9 +1,12 @@
 package br.com.klimber.inova.endpoint;
 
+import br.com.klimber.inova.model.AvailableFeatures;
+import br.com.klimber.inova.service.AvailableFeatureService;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +29,7 @@ public class PbiController {
 
 	private final PbiService pbiService;
 	private final AccessLogService accessLogService;
+	private final AvailableFeatureService featureService;
 
 	@GetMapping("/pbi/groups")
 	public List<Group> getGroups() {
@@ -51,5 +55,11 @@ public class PbiController {
 		Customer customer = (Customer) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		accessLogService.addLogEntry(groupId, reportId, customer.getId());
 		return pbiService.getReportEmbedToken(groupId, reportId);
+	}
+
+	@Secured("ROLE_ADMIN")
+	@GetMapping("/pbi/availableFeatures")
+	public AvailableFeatures getAvailableFeatures() {
+		return featureService.getAvailableFeatures();
 	}
 }

--- a/src/main/java/br/com/klimber/inova/endpoint/TodoEndpoint.java
+++ b/src/main/java/br/com/klimber/inova/endpoint/TodoEndpoint.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import javax.transaction.Transactional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,9 +26,13 @@ public class TodoEndpoint {
 	private final TodoRepository todoRepository;
 
 	@GetMapping("/todoApp/todos")
+	@Transactional
 	public List<Todo> getTodos() {
 		Customer customer = (Customer) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-		return todoRepository.findByCustomer(customer);
+		List<Todo> todos = todoRepository.findByCustomer(customer);
+		if (!todos.isEmpty())
+			todos.get(0).getCustomer().getAuthorities().size();
+		return todos;
 	}
 
 	@PostMapping("/todoApp/todos")

--- a/src/main/java/br/com/klimber/inova/model/AvailableFeatures.java
+++ b/src/main/java/br/com/klimber/inova/model/AvailableFeatures.java
@@ -1,0 +1,26 @@
+package br.com.klimber.inova.model;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class AvailableFeatures {
+
+    private List<AvailableFeature> features;
+
+}
+
+@Data
+class AvailableFeature {
+    String name;
+    String state;
+    String extendedState;
+    AdditionalFeatureInfo additionalInfo;
+
+}
+
+@Data
+class AdditionalFeatureInfo {
+    Integer usage;
+}

--- a/src/main/java/br/com/klimber/inova/model/Customer.java
+++ b/src/main/java/br/com/klimber/inova/model/Customer.java
@@ -1,16 +1,9 @@
 package br.com.klimber.inova.model;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
@@ -40,27 +33,19 @@ public class Customer implements UserDetails {
 	private String username;
 	@NotBlank
 	private String fullName;
-	@NotBlank
+
 	private String extraInfo;
 	@Email
 	@NotBlank
 	private String email;
 	@NotBlank
 	private String password;
-	@ElementCollection(fetch = FetchType.EAGER)
-	private Set<String> authorities;
+	@ManyToOne(optional = false, fetch = FetchType.EAGER)
+	private CustomerProfile profile;
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return this.authorities.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
-	}
-
-	public boolean addAuthority(String authority) {
-		return this.authorities.add(authority);
-	}
-
-	public boolean removeAuthority(String authority) {
-		return this.authorities.remove(authority);
+		return this.profile.getAuthorities().stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
 	}
 
 	@Override

--- a/src/main/java/br/com/klimber/inova/model/Customer.java
+++ b/src/main/java/br/com/klimber/inova/model/Customer.java
@@ -1,7 +1,9 @@
 package br.com.klimber.inova.model;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
@@ -43,9 +45,14 @@ public class Customer implements UserDetails {
 	@ManyToOne(optional = false, fetch = FetchType.EAGER)
 	private CustomerProfile profile;
 
+	@ElementCollection(fetch = FetchType.EAGER)
+	private Set<String> extraAuthorities;
+
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return this.profile.getAuthorities().stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
+		Stream<String> profile = this.profile.getAuthorities().stream();
+		Stream<String> extra = this.getExtraAuthorities().stream();
+		return Stream.concat(profile, extra).map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
 	}
 
 	@Override

--- a/src/main/java/br/com/klimber/inova/model/CustomerProfile.java
+++ b/src/main/java/br/com/klimber/inova/model/CustomerProfile.java
@@ -1,0 +1,32 @@
+package br.com.klimber.inova.model;
+
+import java.util.Set;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@NoArgsConstructor
+public class CustomerProfile {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotBlank
+	@Column(unique = true)
+	private String name;
+
+	@ElementCollection(fetch = FetchType.LAZY)
+	private Set<String> authorities;
+
+	public CustomerProfile(@NotBlank String name, Set<String> authorities) {
+		this.name = name;
+		this.authorities = authorities;
+	}
+
+}

--- a/src/main/java/br/com/klimber/inova/repository/CustomerProfileRepository.java
+++ b/src/main/java/br/com/klimber/inova/repository/CustomerProfileRepository.java
@@ -1,0 +1,11 @@
+package br.com.klimber.inova.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.klimber.inova.model.CustomerProfile;
+
+@Repository
+public interface CustomerProfileRepository extends JpaRepository<CustomerProfile, Long> {
+
+}

--- a/src/main/java/br/com/klimber/inova/service/AvailableFeatureService.java
+++ b/src/main/java/br/com/klimber/inova/service/AvailableFeatureService.java
@@ -1,0 +1,35 @@
+package br.com.klimber.inova.service;
+
+import br.com.klimber.inova.model.AvailableFeatures;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class AvailableFeatureService {
+
+    public static final String GET_AVAILABLE_FEATURES_URL = "https://api.powerbi.com/v1.0/myorg/availableFeatures";
+    private final AzureTokenService tokenService;
+    private final RestTemplate restTemplate;
+
+    private static AvailableFeatures availableFeatures;
+
+    public AvailableFeatures getAvailableFeatures() {
+        if(availableFeatures == null) {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(tokenService.getToken());
+            HttpEntity<Object> request = new HttpEntity<>(headers);
+            availableFeatures = restTemplate.exchange(GET_AVAILABLE_FEATURES_URL, HttpMethod.GET, request,
+                                                      AvailableFeatures.class).getBody();
+        }
+        return availableFeatures;
+    }
+
+    public void clearAvailableFeatures() {
+        availableFeatures = null;
+    }
+}

--- a/src/main/java/br/com/klimber/inova/service/CustomerProfileService.java
+++ b/src/main/java/br/com/klimber/inova/service/CustomerProfileService.java
@@ -1,0 +1,58 @@
+package br.com.klimber.inova.service;
+
+import java.util.List;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import br.com.klimber.inova.model.CustomerProfile;
+import br.com.klimber.inova.repository.CustomerProfileRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerProfileService {
+
+	private final CustomerProfileRepository profileRepository;
+
+	public CustomerProfile findById(Long id) {
+		return profileRepository.findById(id).get();
+	}
+
+	@Transactional
+	public CustomerProfile findByIdWithAuthorities(Long id) {
+		CustomerProfile profile = profileRepository.findById(id).get();
+		// load authorities in transaction
+		profile.getAuthorities().size();
+		return profile;
+
+	}
+
+	public CustomerProfile save(CustomerProfile profile) {
+		return profileRepository.save(profile);
+	}
+
+	public List<CustomerProfile> findAll() {
+		return profileRepository.findAll();
+	}
+
+	public void deleteById(Long id) {
+		profileRepository.deleteById(id);
+	}
+
+	@Transactional
+	public void addAuthority(Long profileId, String authority) {
+		CustomerProfile profile = profileRepository.findById(profileId).get();
+		profile.getAuthorities().add(authority);
+		profileRepository.save(profile);
+	}
+
+	@Transactional
+	public void removeAuthority(Long profileId, String authority) {
+		CustomerProfile profile = profileRepository.findById(profileId).get();
+		profile.getAuthorities().remove(authority);
+		profileRepository.save(profile);
+	}
+
+}

--- a/src/main/java/br/com/klimber/inova/service/CustomerService.java
+++ b/src/main/java/br/com/klimber/inova/service/CustomerService.java
@@ -2,6 +2,8 @@ package br.com.klimber.inova.service;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.domain.Example;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -19,9 +21,14 @@ public class CustomerService implements UserDetailsService {
 	private final CustomerRepository customerRepository;
 
 	@Override
+	@Transactional
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		return customerRepository.findByUsernameIgnoreCase(username)
+		Customer customer = customerRepository.findByUsernameIgnoreCase(username)
 				.orElseThrow(() -> new UsernameNotFoundException("No user found with username " + username));
+		// load authorities, need to be loaded here since Lazy fields need to be loaded
+		// in the same transaction.
+		customer.getAuthorities();
+		return customer;
 	}
 
 	public List<Customer> findAll(Example<Customer> example) {
@@ -39,6 +46,10 @@ public class CustomerService implements UserDetailsService {
 
 	public Customer findById(Long id) {
 		return customerRepository.findById(id).get();
+	}
+
+	public long count() {
+		return customerRepository.count();
 	}
 
 }

--- a/src/main/java/br/com/klimber/inova/service/CustomerService.java
+++ b/src/main/java/br/com/klimber/inova/service/CustomerService.java
@@ -25,9 +25,8 @@ public class CustomerService implements UserDetailsService {
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		Customer customer = customerRepository.findByUsernameIgnoreCase(username)
 				.orElseThrow(() -> new UsernameNotFoundException("No user found with username " + username));
-		// load authorities, need to be loaded here since Lazy fields need to be loaded
-		// in the same transaction.
-		customer.getAuthorities();
+		// need to load authorities inside transaction
+		customer.getAuthorities().size();
 		return customer;
 	}
 
@@ -50,6 +49,18 @@ public class CustomerService implements UserDetailsService {
 
 	public long count() {
 		return customerRepository.count();
+	}
+
+	public void addExtraAuthority(Long customerId, String authority) {
+		Customer customer = findById(customerId);
+		customer.getExtraAuthorities().add(authority);
+		save(customer);
+	}
+
+	public void removeExtraAuthority(Long customerId, String authority) {
+		Customer customer = findById(customerId);
+		customer.getExtraAuthorities().remove(authority);
+		save(customer);
 	}
 
 }

--- a/src/main/java/br/com/klimber/inova/utils/ScheduledTasks.java
+++ b/src/main/java/br/com/klimber/inova/utils/ScheduledTasks.java
@@ -1,5 +1,6 @@
 package br.com.klimber.inova.utils;
 
+import br.com.klimber.inova.service.AvailableFeatureService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -19,13 +20,14 @@ public class ScheduledTasks {
 
 	private final PbiService pbiService;
 	private final AccessLogService logService;
+	private final AvailableFeatureService featureService;
 
 	@Value("${app.remove-log-after-days}")
 	private int remove_log_days;
 
 	@Transactional
 	@Scheduled(fixedRate = 3600000) // Every 1 hour
-	private void update() {
+	public void update() {
 		log.info("Started 'update groups' job");
 		pbiService.updateGroups();
 		log.info("Finished 'update groups' job");
@@ -35,9 +37,15 @@ public class ScheduledTasks {
 	}
 
 	@Scheduled(fixedRate = 86400000)
-	private void deleteOldLogs() {
+	public void deleteOldLogs() {
 		log.info("Started 'delete old logs' job");
 		logService.removeLogsOlderThan(remove_log_days);
 		log.info("Finished 'delete old logs' job");
+	}
+
+	@Scheduled(fixedRate = 3600000)
+	public void clearAvailableFeatures() {
+		featureService.clearAvailableFeatures();
+		log.info("Cleared AvailableFeatures");
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,5 +32,4 @@ app:
     client-id: <azure-client-id>
     client-secret: <azure-client-secret>
     tenant-id: <azure-tenant-id>
-    service-principal: <azure-service-principal>
 

--- a/src/test/java/br/com/klimber/inova/InovaApplicationTests.java
+++ b/src/test/java/br/com/klimber/inova/InovaApplicationTests.java
@@ -2,8 +2,10 @@ package br.com.klimber.inova;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles(value = { "test" })
 class InovaApplicationTests {
 
 	@Test


### PR DESCRIPTION
With the user base growing, it was no longer easy to provide access control on a per-user basis.

As such, a CustomerProfile model was implemented, it will store all authorities, and may be assigned to multiple users, thus giving all users assigned with it the same permissions.

By changing a profile permissions, all users assigned to it will have their permissions changed.

Some adjustments where also made to reduce the size of responses. The responses will now return the authorities only when needed.